### PR TITLE
feat: add arrow key navigation for modal dialogs

### DIFF
--- a/moomoolah/budget_app.py
+++ b/moomoolah/budget_app.py
@@ -7,6 +7,7 @@ from rich.text import Text
 from textual import on, work
 from textual.app import App, ComposeResult
 from textual.containers import Grid
+from textual.events import Key
 from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
@@ -69,6 +70,14 @@ class EntryTypeModal(ModalScreen[EntryType]):
     @on(Button.Pressed, "#add_income")
     def on_add_income(self) -> None:
         self.dismiss(EntryType.INCOME)
+
+    def on_key(self, event: Key) -> None:
+        if event.key == "left":
+            self.focus_previous()
+            event.prevent_default()
+        elif event.key == "right":
+            self.focus_next()
+            event.prevent_default()
 
 
 class UpdateEntryModal(ModalScreen):

--- a/moomoolah/widgets.py
+++ b/moomoolah/widgets.py
@@ -1,6 +1,7 @@
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
+from textual.events import Key
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label
 
@@ -45,3 +46,11 @@ class ConfirmationModal(ModalScreen[bool]):
     @on(Button.Pressed, "#confirmation_no")
     def on_no(self, _) -> None:
         self.dismiss(False)
+
+    def on_key(self, event: Key) -> None:
+        if event.key == "left":
+            self.focus_previous()
+            event.prevent_default()
+        elif event.key == "right":
+            self.focus_next()
+            event.prevent_default()

--- a/tests/test_budget_app.py
+++ b/tests/test_budget_app.py
@@ -565,6 +565,33 @@ class TestConfirmationModal:
             # Modal should be dismissed, check that we're back to main screen
             assert isinstance(app.screen, MainScreen)
 
+    async def test_confirmation_modal_arrow_keys(self, basic_temp_state_file):
+        """Test that left/right arrow keys change focus between buttons."""
+        from moomoolah.widgets import ConfirmationModal
+
+        app = BudgetApp(state_file=basic_temp_state_file)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            modal = ConfirmationModal("Are you sure?")
+
+            # Start the modal
+            app.push_screen(modal)
+            await pilot.pause()
+
+            # Test that arrow keys navigate between buttons
+            await pilot.press("right")
+            await pilot.pause()
+            
+            await pilot.press("left")
+            await pilot.pause()
+
+            # Press Enter on focused button (should be Yes button after left arrow)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # Modal should be dismissed, back to main screen
+            assert isinstance(app.screen, MainScreen)
+
 
 class TestUpdateEntryModal:
     """Test the UpdateEntryModal functionality."""
@@ -892,3 +919,95 @@ class TestUnsavedChanges:
                 assert isinstance(app.screen, MainScreen)
                 # Unsaved changes should still be marked
                 assert app.has_unsaved_changes
+
+
+class TestEntryTypeModal:
+    """Test the EntryTypeModal widget."""
+
+    async def test_entry_type_modal_expense_button(self, basic_temp_state_file):
+        """Test that clicking 'Expense' returns EntryType.EXPENSE."""
+        from moomoolah.budget_app import EntryTypeModal
+        from moomoolah.state import EntryType
+
+        app = BudgetApp(state_file=basic_temp_state_file)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            modal = EntryTypeModal()
+
+            # Start the modal
+            app.push_screen(modal)
+            await pilot.pause()
+
+            # Click Expense button
+            await pilot.click("#add_expense")
+            await pilot.pause()
+
+            # Modal should be dismissed, check that we're back to main screen
+            assert isinstance(app.screen, MainScreen)
+
+    async def test_entry_type_modal_income_button(self, basic_temp_state_file):
+        """Test that clicking 'Income' returns EntryType.INCOME."""
+        from moomoolah.budget_app import EntryTypeModal
+
+        app = BudgetApp(state_file=basic_temp_state_file)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            modal = EntryTypeModal()
+
+            # Start the modal
+            app.push_screen(modal)
+            await pilot.pause()
+
+            # Click Income button
+            await pilot.click("#add_income")
+            await pilot.pause()
+
+            # Modal should be dismissed, check that we're back to main screen
+            assert isinstance(app.screen, MainScreen)
+
+    async def test_entry_type_modal_escape_key(self, basic_temp_state_file):
+        """Test that escape key cancels the modal."""
+        from moomoolah.budget_app import EntryTypeModal
+
+        app = BudgetApp(state_file=basic_temp_state_file)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            modal = EntryTypeModal()
+
+            # Start the modal
+            app.push_screen(modal)
+            await pilot.pause()
+
+            # Press escape to cancel
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Modal should be dismissed, check that we're back to main screen
+            assert isinstance(app.screen, MainScreen)
+
+    async def test_entry_type_modal_arrow_keys(self, basic_temp_state_file):
+        """Test that left/right arrow keys change focus between buttons."""
+        from moomoolah.budget_app import EntryTypeModal
+
+        app = BudgetApp(state_file=basic_temp_state_file)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            modal = EntryTypeModal()
+
+            # Start the modal
+            app.push_screen(modal)
+            await pilot.pause()
+
+            # Test that arrow keys navigate between buttons
+            await pilot.press("right")
+            await pilot.pause()
+            
+            await pilot.press("left")
+            await pilot.pause()
+
+            # Press Enter on focused button (should be Expense button after left arrow)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            # Modal should be dismissed, back to main screen
+            assert isinstance(app.screen, MainScreen)


### PR DESCRIPTION
## Summary
- Add left/right arrow key support for modal dialog navigation
- Implement arrow key focus switching in ConfirmationModal (Yes/No buttons)
- Implement arrow key focus switching in EntryTypeModal (Expense/Income buttons)
- Use on_key handlers instead of BINDINGS to avoid showing keys in help footer

## Test plan
- [x] Test arrow key navigation in ConfirmationModal
- [x] Test arrow key navigation in EntryTypeModal  
- [x] Verify existing modal functionality still works
- [x] All tests pass
- [x] Code passes linting